### PR TITLE
Fix PDF unlock context

### DIFF
--- a/src/pdf/pdf.py
+++ b/src/pdf/pdf.py
@@ -91,11 +91,12 @@ def desbloquear(caminho_arquivo: str) -> Union[bool, None]:
         Union[bool, None]: Retorna True se o PDF foi desbloqueado com sucesso,
         None caso contrário.
     """
-    pdf = pikepdf.open(caminho_arquivo, allow_overwriting_input=True)
     try:
         print("Desbloqueando PDF...")
-        pdf.save(caminho_arquivo)
+        with pikepdf.open(caminho_arquivo, allow_overwriting_input=True) as pdf:
+            pdf.save(caminho_arquivo)
         print(f"PDF {caminho_arquivo} desbloqueado com sucesso!")
+        return True
     except Exception as e:
         print(f"Erro no desbloqueio do PDF: {str(e)}")
         return False


### PR DESCRIPTION
## Summary
- handle unlocking PDFs with a `with` context

## Testing
- `python3 -m py_compile src/pdf/pdf.py`

------
https://chatgpt.com/codex/tasks/task_e_686bd80e3944832183a278043830e4cf