### PR TITLE
Enable API key refresh in runtime

### DIFF
--- a/src/gui.py
+++ b/src/gui.py
@@ -7,7 +7,7 @@ from src.pdf.pdf import PDFGUI
 from src.edicao.edicao import EdicaoGUI
 from src.config.config import ConfigGUI, api_disponivel
 from PIL import Image, ImageTk
-from src.requisitos import verificar_ffmpeg_instalado
+from src.requisitos import verificar_ffmpeg_instalado, verificar_api_key
 import webbrowser
 import os
 from dotenv import load_dotenv
@@ -26,6 +26,10 @@ class MainGUI:
         self.root.title("Estudante v1.3")
         self.root.iconbitmap("src/icone.ico")
 
+        # Referências aos botões que dependem da API
+        self.botao_resumo = None
+        self.botao_pdf = None
+
 
         self.criar_frame_botoes()
         self.criar_botoes()
@@ -39,20 +43,21 @@ class MainGUI:
     def criar_botoes(self) -> None:
         """Cria os botões principais com ícones."""
         botoes = [
-            ("src/transcricao/transcrever.png", "Transcrever", self.abrir_transcricao if ffmpeg_instalado else None, tk.NORMAL if ffmpeg_instalado else tk.DISABLED),
-            ("src/resumo/resumir.png", "Resumir", self.abrir_resumo, tk.NORMAL if api_disponivel else tk.DISABLED),
-            ("src/pdf/pdf.png", "PDF", self.abrir_pdf, tk.NORMAL if api_disponivel else tk.DISABLED),
-            ("src/edicao/editar.png", "Revisar", self.abrir_edicao),
-            ("src/leiturinha/leiturinha.png", "Leiturinha", self.abrir_leiturinha),
-            ("src/config/config.png", "Configurações", self.abrir_configuracoes),
-            ("src/leiame/leia_me.png", "Leia-me", self.abrir_leiame_html)
-
+            ("src/transcricao/transcrever.png", "Transcrever", self.abrir_transcricao if ffmpeg_instalado else None, tk.NORMAL if ffmpeg_instalado else tk.DISABLED, None),
+            ("src/resumo/resumir.png", "Resumir", self.abrir_resumo, tk.NORMAL if api_disponivel else tk.DISABLED, "botao_resumo"),
+            ("src/pdf/pdf.png", "PDF", self.abrir_pdf, tk.NORMAL if api_disponivel else tk.DISABLED, "botao_pdf"),
+            ("src/edicao/editar.png", "Revisar", self.abrir_edicao, tk.NORMAL, None),
+            ("src/leiturinha/leiturinha.png", "Leiturinha", self.abrir_leiturinha, tk.NORMAL, None),
+            ("src/config/config.png", "Configurações", self.abrir_configuracoes, tk.NORMAL, None),
+            ("src/leiame/leia_me.png", "Leia-me", self.abrir_leiame_html, tk.NORMAL, None)
         ]
 
-        for caminho_imagem, texto, comando, *estado in botoes:
-            self.criar_botao_icone(self.frame_botoes, caminho_imagem, texto, comando, estado[0] if estado else tk.NORMAL)
+        for caminho_imagem, texto, comando, estado, atributo in botoes:
+            botao = self.criar_botao_icone(self.frame_botoes, caminho_imagem, texto, comando, estado)
+            if atributo:
+                setattr(self, atributo, botao)
 
-    def criar_botao_icone(self, frame: tk.Frame, caminho_imagem: str, texto: str, comando: callable, estado: str = tk.NORMAL) -> None:
+    def criar_botao_icone(self, frame: tk.Frame, caminho_imagem: str, texto: str, comando: callable, estado: str = tk.NORMAL) -> tk.Button:
         """Cria um botão com ícone e texto.
 
         Args:
@@ -68,6 +73,7 @@ class MainGUI:
         botao = tk.Button(frame, image=icone, text=texto, compound="top", command=comando, state=estado)
         botao.image = icone
         botao.pack(side="left", padx=10)
+        return botao
 
     def criar_label_creditos(self) -> None:
         """Cria um label para créditos."""
@@ -100,10 +106,22 @@ class MainGUI:
         nova_janela = tk.Toplevel(self.root)
         LeiturinhaGUI(nova_janela)
 
+    def atualizar_botoes_api(self) -> None:
+        """Atualiza o estado dos botões que dependem da API."""
+        disponivel = verificar_api_key()
+        estado = tk.NORMAL if disponivel else tk.DISABLED
+        if self.botao_resumo:
+            self.botao_resumo.config(state=estado)
+        if self.botao_pdf:
+            self.botao_pdf.config(state=estado)
+
     def abrir_configuracoes(self) -> None:
         """Abre a janela de configurações."""
         nova_janela = tk.Toplevel(self.root)
         ConfigGUI(nova_janela)
+        nova_janela.grab_set()
+        nova_janela.wait_window()
+        self.atualizar_botoes_api()
 
     def abrir_leiame_html(self) -> None:
         """Abre o conteúdo do README em uma nova janela."""


### PR DESCRIPTION
## Summary
- store references to API-dependent buttons
- refresh these buttons after closing configuration
- add helper to check API availability without restart

## Testing
- `python -m py_compile src/gui.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bfb88ba0083218e7e0b433315c0cc