### PR TITLE
Refactor GUI windows to share common base class

### DIFF
--- a/src/edicao/edicao.py
+++ b/src/edicao/edicao.py
@@ -6,30 +6,29 @@ from PIL import Image, ImageTk
 
 from src.utils import gravar_documento, abrir_doc_produzido
 from src.utils_ia import revisar
-from src.utils_gui import imagem_na_janela_secundaria
+from src.utils_gui import imagem_na_janela_secundaria, BaseWindow
 
-class EdicaoGUI:
+class EdicaoGUI(BaseWindow):
     def __init__(self, root: tk.Tk) -> None:
         """Inicializa a GUI de edição.
 
         Args:
             root (tk.Tk): A instância raiz do Tkinter.
         """
-        self.root = root
-        self.root.title("Revisar")
+        super().__init__(root, "Revisar")
         self.idioma_var = tk.StringVar(value="pt")
 
         self.caminho_arquivo_imagem = "src/edicao/editar.png"
 
         # Imagem no topo da janela
-        imagem_na_janela_secundaria(self.root, self.caminho_arquivo_imagem)
+        imagem_na_janela_secundaria(self.main_frame, self.caminho_arquivo_imagem)
 
         # Frame para upload de DOCX
-        tk.Label(root, text="Escolha o arquivo DOCX:").pack()
-        tk.Button(root, text="Selecionar arquivo DOCX", command=self.selecionar_docx).pack(pady=10)
+        tk.Label(self.main_frame, text="Escolha o arquivo DOCX:").pack()
+        tk.Button(self.main_frame, text="Selecionar arquivo DOCX", command=self.selecionar_docx).pack(pady=10)
 
         # Frame para escolha do idioma
-        self.frame_idioma = tk.Frame(root)
+        self.frame_idioma = tk.Frame(self.main_frame)
         tk.Label(self.frame_idioma, text="Escolha o idioma:").pack()
         opcoes_idioma = ["pt", "en"]
         self.menu_idioma = tk.OptionMenu(self.frame_idioma, self.idioma_var, *opcoes_idioma)
@@ -37,7 +36,7 @@ class EdicaoGUI:
         self.frame_idioma.pack(pady=5)
 
         # Botão Enviar
-        self.botao_enviar = tk.Button(root, text="Enviar", command=self.enviar_edicao, state=tk.DISABLED)
+        self.botao_enviar = tk.Button(self.main_frame, text="Enviar", command=self.enviar_edicao, state=tk.DISABLED)
         self.botao_enviar.pack(pady=10)
 
     def selecionar_docx(self) -> None:

--- a/src/leiturinha/leiturinha.py
+++ b/src/leiturinha/leiturinha.py
@@ -1,13 +1,13 @@
 import tkinter as tk
 from tkinter import filedialog, messagebox
 from src.leiturinha.leiturinha_utils import extrair_texto, centralizar_palavra
+from src.utils_gui import BaseWindow
 
 
-class LeiturinhaGUI:
+class LeiturinhaGUI(BaseWindow):
     def __init__(self, root: tk.Tk) -> None:
         """Inicializa a GUI da Leiturinha."""
-        self.root = root
-        self.root.title("Leiturinha - leitura rápida visual")
+        super().__init__(root, "Leiturinha - leitura rápida visual")
 
         # Configurações da interface principal
         self.setup_interface()
@@ -19,40 +19,48 @@ class LeiturinhaGUI:
 
     def setup_interface(self):
         """Configura a interface de seleção e controle."""
-        tk.Label(self.root, text="Escolha o arquivo de texto:").pack()
-        tk.Button(self.root, text="Selecionar arquivo de texto", command=self.processar_texto).pack()
+        tk.Label(self.main_frame, text="Escolha o arquivo de texto:").pack()
+        tk.Button(self.main_frame, text="Selecionar arquivo de texto", command=self.processar_texto).pack()
 
         # Configura controles de velocidade e fonte
         self.velocidade_var = tk.IntVar(value=200)
         self.slider_velocidade = tk.Scale(
-            self.root, from_=100, to=600, orient="horizontal", variable=self.velocidade_var,
+            self.main_frame,
+            from_=100,
+            to=600,
+            orient="horizontal",
+            variable=self.velocidade_var,
             label="Velocidade (palavras por minuto)"
         )
         self.slider_velocidade.pack(pady=5)
 
         self.tamanho_fonte_var = tk.IntVar(value=36)
         self.slider_fonte = tk.Scale(
-            self.root, from_=24, to=100, orient="horizontal", variable=self.tamanho_fonte_var,
+            self.main_frame,
+            from_=24,
+            to=100,
+            orient="horizontal",
+            variable=self.tamanho_fonte_var,
             label="Tamanho da Fonte"
         )
         self.slider_fonte.pack(pady=5)
 
         # Opções de tela cheia e negrito
         self.tela_cheia_var = tk.BooleanVar()
-        tk.Checkbutton(self.root, text="Tela cheia", variable=self.tela_cheia_var).pack()
+        tk.Checkbutton(self.main_frame, text="Tela cheia", variable=self.tela_cheia_var).pack()
 
         self.negrito_var = tk.BooleanVar()
-        tk.Checkbutton(self.root, text="Negritar as três primeiras letras", variable=self.negrito_var).pack()
+        tk.Checkbutton(self.main_frame, text="Negritar as três primeiras letras", variable=self.negrito_var).pack()
 
         # Botão Iniciar
-        tk.Button(self.root, text="Iniciar Leiturinha", command=self.abrir_janela_leiturinha).pack(pady=10)
+        tk.Button(self.main_frame, text="Iniciar Leiturinha", command=self.abrir_janela_leiturinha).pack(pady=10)
 
     def processar_texto(self) -> None:
         """Abre um diálogo para selecionar um arquivo de texto."""
         self.caminho_arquivo = filedialog.askopenfilename(
             filetypes=[("Arquivos de texto", "*.txt *.pdf *.docx *.html")])
         if self.caminho_arquivo:
-            tk.Label(self.root, text=f"Arquivo selecionado: {self.caminho_arquivo}").pack()
+            tk.Label(self.main_frame, text=f"Arquivo selecionado: {self.caminho_arquivo}").pack()
 
     def abrir_janela_leiturinha(self) -> None:
         """Abre a janela de exibição da Leiturinha."""

--- a/src/pdf/pdf.py
+++ b/src/pdf/pdf.py
@@ -6,7 +6,7 @@ from PIL import Image, ImageTk
 from docx import Document
 from dotenv import load_dotenv
 from src.utils import reconhecer_ocr, adicionar_com_subtitulos, gravar_documento, abrir_doc_produzido
-from src.utils_gui import imagem_na_janela_secundaria
+from src.utils_gui import imagem_na_janela_secundaria, BaseWindow
 from src.requisitos import verificar_tesseract_instalado
 
 load_dotenv()
@@ -16,33 +16,38 @@ tesseract_instalado : bool = verificar_tesseract_instalado()
 
 
 
-class PDFGUI:
+class PDFGUI(BaseWindow):
     def __init__(self, root: tk.Tk) -> None:
         """Inicializa a GUI de OCR e desbloqueio de PDF.
 
         Args:
             root (tk.Tk): A instância raiz do Tkinter.
         """
-        self.root = root
-        self.root.title("PDF")
+        super().__init__(root, "PDF")
 
         self.caminho_arquivo_imagem = "src/pdf/pdf.png"
 
         # Imagem no topo da janela
-        imagem_na_janela_secundaria(self.root, self.caminho_arquivo_imagem)
+        imagem_na_janela_secundaria(self.main_frame, self.caminho_arquivo_imagem)
 
         # Frame para upload de PDF
-        tk.Label(root, text="Escolha o arquivo PDF:").pack()
-        tk.Button(root, text="Selecionar arquivo PDF", command=self.selecionar_pdf).pack(pady=10)
+        tk.Label(self.main_frame, text="Escolha o arquivo PDF:").pack()
+        tk.Button(self.main_frame, text="Selecionar arquivo PDF", command=self.selecionar_pdf).pack(pady=10)
 
         # Frame para escolha do modo
         self.modo_var = tk.StringVar(value="ocr")
-        tk.Label(root, text="Escolha o modo:").pack()
-        tk.Radiobutton(root, text="OCR", variable=self.modo_var, value="ocr", state=tk.NORMAL if tesseract_instalado else tk.DISABLED).pack(anchor=tk.W)
-        tk.Radiobutton(root, text="Desbloquear", variable=self.modo_var, value="desbloquear").pack(anchor=tk.W)
+        tk.Label(self.main_frame, text="Escolha o modo:").pack()
+        tk.Radiobutton(
+            self.main_frame,
+            text="OCR",
+            variable=self.modo_var,
+            value="ocr",
+            state=tk.NORMAL if tesseract_instalado else tk.DISABLED,
+        ).pack(anchor=tk.W)
+        tk.Radiobutton(self.main_frame, text="Desbloquear", variable=self.modo_var, value="desbloquear").pack(anchor=tk.W)
 
         # Botão Enviar
-        self.botao_enviar = tk.Button(root, text="Enviar", command=self.enviar, state=tk.DISABLED)
+        self.botao_enviar = tk.Button(self.main_frame, text="Enviar", command=self.enviar, state=tk.DISABLED)
         self.botao_enviar.pack(pady=10)
 
     def selecionar_pdf(self) -> None:

--- a/src/resumo/resumo.py
+++ b/src/resumo/resumo.py
@@ -6,42 +6,41 @@ from PIL import Image, ImageTk
 from docx import Document
 
 from src.utils import extrair_texto, adicionar_com_subtitulos, gravar_documento, abrir_doc_produzido, limpar_temp
-from src.utils_gui import imagem_na_janela_secundaria
+from src.utils_gui import imagem_na_janela_secundaria, BaseWindow
 from src.utils_ia import resumir_texto
 
 
-class ResumoGUI:
+class ResumoGUI(BaseWindow):
     def __init__(self, root: tk.Tk) -> None:
         """Inicializa a GUI de resumo.
 
         Args:
             root (tk.Tk): A instância raiz do Tkinter.
         """
-        self.root = root
-        self.root.title("Resumo")
+        super().__init__(root, "Resumo")
         caminho_arquivo_imagem = "src/resumo/resumir.png"
 
         # Imagem no topo da janela
-        imagem_na_janela_secundaria(self.root, caminho_arquivo_imagem)
+        imagem_na_janela_secundaria(self.main_frame, caminho_arquivo_imagem)
 
         # Frame para upload de texto
-        tk.Label(root, text="Escolha o arquivo de texto:").pack()
-        tk.Button(root, text="Selecionar arquivo de texto", command=self.selecionar_texto).pack(pady=10)
+        tk.Label(self.main_frame, text="Escolha o arquivo de texto:").pack()
+        tk.Button(self.main_frame, text="Selecionar arquivo de texto", command=self.selecionar_texto).pack(pady=10)
 
         # Seleção do modo de resumo
-        tk.Label(root, text="Escolha o modo de resumo:").pack()
+        tk.Label(self.main_frame, text="Escolha o modo de resumo:").pack()
         self.modo_resumo = tk.StringVar(value="geral")
         modos = [("Geral", "geral"), ("Jurisprudência", "jurisprudencia"), ("Retórica", "retorica"), ("Personalizado", "personalizado")]
         for texto, valor in modos:
-            tk.Radiobutton(root, text=texto, variable=self.modo_resumo, value=valor, command=self.toggle_prompt).pack(anchor=tk.W)
+            tk.Radiobutton(self.main_frame, text=texto, variable=self.modo_resumo, value=valor, command=self.toggle_prompt).pack(anchor=tk.W)
 
         # Caixa de texto para o prompt personalizado
-        self.prompt_text = tk.Text(root, height=10, width=50)
+        self.prompt_text = tk.Text(self.main_frame, height=10, width=50)
         self.prompt_text.pack(padx=20, pady=10)
         self.prompt_text.pack_forget()
 
         # Botão Enviar
-        self.botao_enviar = tk.Button(root, text="Enviar", command=self.enviar_resumo, state=tk.DISABLED if not hasattr(self, 'caminho_texto') else tk.NORMAL)
+        self.botao_enviar = tk.Button(self.main_frame, text="Enviar", command=self.enviar_resumo, state=tk.DISABLED if not hasattr(self, 'caminho_texto') else tk.NORMAL)
         self.botao_enviar.pack(pady=10)
 
     def selecionar_texto(self) -> None:

--- a/src/transcricao/transcricao.py
+++ b/src/transcricao/transcricao.py
@@ -7,7 +7,11 @@ from dotenv import load_dotenv
 import os
 
 from src.utils import download_yt, dividir_audio, transcrever_partes, gravar_documento, abrir_doc_produzido, limpar_temp, suprimir_avisos
-from src.utils_gui import imagem_na_janela_secundaria, checkbox_mostrar_log_simplificado
+from src.utils_gui import (
+    imagem_na_janela_secundaria,
+    checkbox_mostrar_log_simplificado,
+    BaseWindow,
+)
 # Carrega as variáveis de ambiente do arquivo .env
 load_dotenv()
 
@@ -17,17 +21,16 @@ api_disponivel = api_key is not None
 
 caminho_arquivo_imagem = "src/transcricao/transcrever.png"
 
-class TranscricaoGUI:
+class TranscricaoGUI(BaseWindow):
     def __init__(self, root: tk.Tk) -> None:
         """Inicializa a GUI de transcrição.
 
         Args:
             root (tk.Tk): A instância raiz do Tkinter.
         """
-        self.root = root
-        self.root.title("Transcrever")
+        super().__init__(root, "Transcrever")
 
-        imagem_na_janela_secundaria(self.root, caminho_arquivo_imagem)
+        imagem_na_janela_secundaria(self.main_frame, caminho_arquivo_imagem)
 
         # Variáveis de controle
         self.tipo_midia_var = tk.StringVar(value="audio")
@@ -37,26 +40,36 @@ class TranscricaoGUI:
         self.mostrar_log_var = tk.BooleanVar(value=False)  # Variável de controle para o checkbox
 
         # Botões de rádio para selecionar o tipo de mídia
-        tk.Label(root, text="Escolha o tipo de mídia:").pack(pady=5)
-        tk.Radiobutton(root, text="Arquivo de Áudio", variable=self.tipo_midia_var, value="audio",
-                       command=self.toggle_input).pack()
-        tk.Radiobutton(root, text="Vídeo do YouTube", variable=self.tipo_midia_var, value="youtube",
-                       command=self.toggle_input).pack()
+        tk.Label(self.main_frame, text="Escolha o tipo de mídia:").pack(pady=5)
+        tk.Radiobutton(
+            self.main_frame,
+            text="Arquivo de Áudio",
+            variable=self.tipo_midia_var,
+            value="audio",
+            command=self.toggle_input,
+        ).pack()
+        tk.Radiobutton(
+            self.main_frame,
+            text="Vídeo do YouTube",
+            variable=self.tipo_midia_var,
+            value="youtube",
+            command=self.toggle_input,
+        ).pack()
 
         # Frame para upload de áudio
-        self.frame_audio = tk.Frame(root)
+        self.frame_audio = tk.Frame(self.main_frame)
         tk.Label(self.frame_audio, text="Escolha o arquivo de áudio:").pack()
         tk.Button(self.frame_audio, text="Selecionar arquivo de áudio", command=self.processar_audio).pack()
 
         # Frame para URL do YouTube (inicialmente escondido)
-        self.frame_youtube = tk.Frame(root)
+        self.frame_youtube = tk.Frame(self.main_frame)
         tk.Label(self.frame_youtube, text="Insira o link do YouTube:").pack()
         self.youtube_url_entry = tk.Entry(self.frame_youtube, width=50)
         self.youtube_url_entry.pack()
         self.frame_youtube.pack_forget()
 
         # Frame para escolha do idioma
-        self.frame_idioma = tk.Frame(root)
+        self.frame_idioma = tk.Frame(self.main_frame)
         tk.Label(self.frame_idioma, text="Escolha o idioma:").pack()
         opcoes_idioma = ["pt", "en", "es", "fr", "it"]
         self.menu_idioma = tk.OptionMenu(self.frame_idioma, self.idioma_var, *opcoes_idioma)
@@ -67,7 +80,7 @@ class TranscricaoGUI:
         self.whisper_model_var = tk.StringVar(value="base")
 
         # Frame para escolha do modelo Whisper (aparece apenas quando Whisper Local é selecionado)
-        self.frame_whisper_model = tk.Frame(root)
+        self.frame_whisper_model = tk.Frame(self.main_frame)
         tk.Label(self.frame_whisper_model, text="Escolha o modelo Whisper local:").pack()
         opcoes_whisper_model = ["tiny", "base", "small", "medium", "large"]
         self.menu_whisper_model = tk.OptionMenu(self.frame_whisper_model, self.whisper_model_var,
@@ -75,20 +88,20 @@ class TranscricaoGUI:
         self.menu_whisper_model.pack()
 
         self.metodo_var.trace_add('write', self.toggle_whisper_model_frame)
-        self.frame_metodo = tk.Frame(root)
+        self.frame_metodo = tk.Frame(self.main_frame)
         tk.Label(self.frame_metodo, text="Escolha o método de transcrição:").pack()
         tk.Radiobutton(self.frame_metodo, text="Usar API da OpenAI", variable=self.metodo_var, value="api",
                        state=tk.NORMAL if api_disponivel else tk.DISABLED).pack()
         tk.Radiobutton(self.frame_metodo, text="Usar Whisper Local", variable=self.metodo_var, value="local").pack()
 
         # Checkbox para timestamp
-        self.frame_timestamp = tk.Frame(root)
+        self.frame_timestamp = tk.Frame(self.main_frame)
         self.checkbox_timestamp = tk.Checkbutton(self.frame_timestamp, text="Com timestamp",
                                                  variable=self.timestamp_var)
         self.checkbox_timestamp.pack()
 
         # Botão Enviar
-        self.botao_enviar = tk.Button(root, text="Enviar", command=self.enviar)
+        self.botao_enviar = tk.Button(self.main_frame, text="Enviar", command=self.enviar)
         self.botao_enviar.pack(pady=10)
 
         # Inicialmente, mostrar apenas a seleção de áudio
@@ -98,7 +111,7 @@ class TranscricaoGUI:
 
         # Checkbox para controlar logs simplificados
         self.frame_timestamp.pack(pady=5)
-        checkbox_mostrar_log_simplificado(root, self.mostrar_log_var)
+        checkbox_mostrar_log_simplificado(self.main_frame, self)
 
 
 

--- a/src/utils_gui.py
+++ b/src/utils_gui.py
@@ -3,6 +3,22 @@ from typing import Optional, Tuple, Callable
 from PIL import Image, ImageTk
 
 
+class BaseWindow:
+    """Janela base com título, ícone e frame principal."""
+
+    def __init__(self, root: tk.Tk, title: str, icon_path: str = "src/icone.ico") -> None:
+        self.root = root
+        self.root.title(title)
+        try:
+            self.root.iconbitmap(icon_path)
+        except Exception:
+            # Pode falhar em sistemas sem suporte ao formato do ícone
+            pass
+
+        self.main_frame = tk.Frame(self.root)
+        self.main_frame.pack(padx=10, pady=10)
+
+
 def configurar_log(root: tk.Tk, mostrar_log_var: Optional[tk.BooleanVar] = None) -> Tuple[tk.Frame, tk.Text, Callable[[str], None]]:
     """Configura um frame de log na janela root."""
     log_frame = tk.Frame(root)


### PR DESCRIPTION
## Summary
- add `BaseWindow` helper in `utils_gui`
- refactor Transcricao, Resumo, PDF, Edicao and Leiturinha GUIs to inherit from `BaseWindow`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686c0135668c8321ac024d8e8f02a56d