### PR TITLE
Use BASE_DIR for image paths

### DIFF
--- a/src/gui.py
+++ b/src/gui.py
@@ -7,6 +7,7 @@ from src.pdf.pdf import PDFGUI
 from src.edicao.edicao import EdicaoGUI
 from src.config.config import ConfigGUI, api_disponivel
 from PIL import Image, ImageTk
+from src.utils.load_env import BASE_DIR
 from src.requisitos import verificar_ffmpeg_instalado, verificar_api_key
 import webbrowser
 import os
@@ -24,7 +25,7 @@ class MainGUI:
         """
         self.root = root
         self.root.title("Estudante v1.3")
-        self.root.iconbitmap("src/icone.ico")
+        self.root.iconbitmap(str(BASE_DIR / "src" / "icone.ico"))
 
         # Referências aos botões que dependem da API
         self.botao_resumo = None
@@ -67,7 +68,7 @@ class MainGUI:
             comando (callable): A função a ser chamada quando o botão for clicado.
             estado (str, optional): O estado inicial do botão. Padrão é tk.NORMAL.
         """
-        imagem = Image.open(caminho_imagem)
+        imagem = Image.open(BASE_DIR / caminho_imagem)
         imagem = imagem.resize((50, 50), Image.LANCZOS)
         icone = ImageTk.PhotoImage(imagem)
         botao = tk.Button(frame, image=icone, text=texto, compound="top", command=comando, state=estado)

--- a/src/utils_gui.py
+++ b/src/utils_gui.py
@@ -1,6 +1,7 @@
 import tkinter as tk
 from typing import Optional, Tuple, Callable
 from PIL import Image, ImageTk
+from src.utils.load_env import BASE_DIR
 
 
 def configurar_log(root: tk.Tk, mostrar_log_var: Optional[tk.BooleanVar] = None) -> Tuple[tk.Frame, tk.Text, Callable[[str], None]]:
@@ -29,7 +30,7 @@ def abrir_janela_log(root: tk.Tk, mostrar_log_var: Optional[tk.BooleanVar] = Non
 
 def imagem_na_janela_secundaria(root, caminho_arquivo_imagem: str) -> None:
     # Imagem no topo da janela
-    imagem = Image.open(caminho_arquivo_imagem)
+    imagem = Image.open(BASE_DIR / caminho_arquivo_imagem)
     imagem = imagem.resize((100, 100), Image.LANCZOS)  # Redimensionar a imagem
     icone = ImageTk.PhotoImage(imagem)
     imagem_label = tk.Label(root, image=icone)


### PR DESCRIPTION
## Summary
- make icon and button images load relative to `BASE_DIR`
- update helper so images open from `BASE_DIR`

## Testing
- `python -m pip install -r requirements.txt` *(fails: ResolutionImpossible)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c013993948321991110aa6f4f8790